### PR TITLE
fix: axe DevTools Critical Issues

### DIFF
--- a/src/components/ColorPanel.vue
+++ b/src/components/ColorPanel.vue
@@ -9,7 +9,11 @@
       @click="changeColor(c)"
     ></div>
   </div>
+  <label for="input-color" class="visually-hidden">
+    {{ t("labels.colorPicker") }}
+  </label>
   <input
+    id="input-color"
     type="color"
     class="input-color"
     :value="color"
@@ -19,6 +23,7 @@
 
 <script lang="ts">
 import { defineComponent, PropType } from "@vue/runtime-core";
+import { useI18n } from "vue-i18n";
 
 export default defineComponent({
   props: {
@@ -33,6 +38,8 @@ export default defineComponent({
   },
   emits: ["update:color"],
   setup(_, ctx) {
+    const { t } = useI18n();
+
     const changeInputColor = (e: any) => {
       changeColor(e.target.value);
     };
@@ -41,6 +48,7 @@ export default defineComponent({
       ctx.emit("update:color", color);
     };
     return {
+      t,
       changeColor,
       changeInputColor,
     };
@@ -70,5 +78,20 @@ export default defineComponent({
 
 .input-color {
   margin-top: 10px;
+}
+
+.visually-hidden {
+  position: fixed;
+  top: 0px;
+  left: 0px;
+  width: 4px;
+  height: 4px;
+  opacity: 0;
+  overflow: hidden;
+  border: none;
+  margin: 0;
+  padding: 0;
+  display: block;
+  visibility: visible;
 }
 </style>

--- a/src/components/GitTag.vue
+++ b/src/components/GitTag.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="fork__tag" @click="openGithub">
-    <img :src="githubIcon" class="github__icon" />
+    <img :src="githubIcon" class="github__icon" alt="github icon" />
     <div class="fork__description">Code is here!</div>
   </div>
 </template>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,7 +13,8 @@
     "color": "color",
     "fontFamily": "font family",
     "fontWeight": "font type",
-    "background": "background color"
+    "background": "background color",
+    "colorPicker": "color picker"
   },
   "selectButtonsOption": {
     "fontFamily": {

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -13,7 +13,8 @@
     "color": "カラー",
     "fontFamily": "フォント",
     "fontWeight": "太さ",
-    "background": "出力画像の背景色"
+    "background": "出力画像の背景色",
+    "colorPicker": "カラーピッカー"
   },
   "selectButtonsOption": {
     "fontFamily": {


### PR DESCRIPTION
## Details
Use to [axe DevTools](https://chrome.google.com/webstore/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd) to resolve critical accessibility issues.

## Images must have alternate text

Ensures `<img>` elements have alternate text or a role of none or presentation.
I've added alt attributes and alternative text to the icon image that links to the GitHub repository ([ef847a6](https://github.com/kawamataryo/animated-emoji-gen/commit/ef847a6e2291e183c9759f5fdd741b38554323a4)).

<img width="234" alt="Screen Shot: GitHub repository link in the upper right corner of the screen is selected in Chrome Elements." src="https://user-images.githubusercontent.com/1996642/129435105-17d2667e-0f7c-47da-9f39-99176d2fb570.png">

## Form elements must have labels

Ensures every form element has a label.
No label was found for `<input type="color">`. Since it is not visually presented in the current design, I created a hidden label using the [visually-hidden](https://webaim.org/techniques/css/invisiblecontent/) technique ([51b9340](https://github.com/kawamataryo/animated-emoji-gen/commit/51b9340a8493d576477c5c896585d1cf62f4849d)).

<img width="106" alt="Screen Shot: Color picker user interface" src="https://user-images.githubusercontent.com/1996642/129435118-1d27a659-cf53-4932-8d4c-a8a19631c101.png">

## Result

<table>
  <tr>
	<th>Currently
	<th>Fixed
  <tr>
	<td><img width="498" alt="Currently: axe DevTools total result 27 issues screenshot" src="https://user-images.githubusercontent.com/1996642/129435079-6fa2f07e-0068-4f6b-950d-196d67c98693.png">
	<td><img width="493" alt="Fixed: axe DevTools total result 25 issues screenshot" src="https://user-images.githubusercontent.com/1996642/129435517-4ebe130c-d5df-4625-8e90-15cdcbbe6917.png">
